### PR TITLE
Fix Wrong ResponseCode issue, remove duplicated log {msg}, add Respon…

### DIFF
--- a/lib/TeamcityReporter.js
+++ b/lib/TeamcityReporter.js
@@ -37,7 +37,7 @@ class TeamcityReporter {
             const responseCode = (this.currItem.response && this.currItem.response.code) || "-";
             const reason = (this.currItem.response && this.currItem.response.reason()) || "-";
             const details = this.escape(`Response code: ${responseCode}, reason: ${reason}`);
-            console.log(`##teamcity[testFailed name='${this.currItem.name}' details='${msg} - ${details}' flowId='${this.flowId}']`);
+            console.log(`##teamcity[testFailed name='${this.currItem.name}' message='${msg}' details='${msg} - ${details}' flowId='${this.flowId}']`);
         }
         const duration = (this.currItem.response && this.currItem.response.responseTime) || 0;
         console.log(`##teamcity[testFinished name='${this.currItem.name}' duration='${duration}' flowId='${this.flowId}']`);

--- a/lib/TeamcityReporter.js
+++ b/lib/TeamcityReporter.js
@@ -34,7 +34,7 @@ class TeamcityReporter {
     item(err, args) {
         if (!this.currItem.passed) {
             const msg = this.escape(this.currItem.failedAssertions.join(", "));
-            const responseCode = this.currItem.response.code;
+            const responseCode = (this.currItem.response && this.currItem.response.code) || "-";
             const reason = (this.currItem.response && this.currItem.response.reason()) || "-";
             const details = this.escape(`Response code: ${responseCode}, reason: ${reason}`);
             console.log(`##teamcity[testFailed name='${this.currItem.name}' details='${msg} - ${details}' flowId='${this.flowId}']`);

--- a/lib/TeamcityReporter.js
+++ b/lib/TeamcityReporter.js
@@ -33,10 +33,19 @@ class TeamcityReporter {
     item(err, args) {
         if (!this.currItem.passed) {
             const msg = this.escape(this.currItem.failedAssertions.join(", "));
-            const responseCode = (this.currItem.response && this.currItem.response.responseTime) || "-";
+            const responseCode = this.currItem.response.code;
             const reason = (this.currItem.response && this.currItem.response.reason()) || "-";
             const details = this.escape(`Response code: ${responseCode}, reason: ${reason}`);
-            console.log(`##teamcity[testFailed name='${this.currItem.name}' message='${msg}' details='${msg} - ${details}']`);
+            console.log(`##teamcity[testFailed name='${this.currItem.name}' details='${msg} - ${details}']`);
+            var responseBody;
+			try {
+				responseBody = JSON.stringify(this.currItem.response.json());
+				responseBody = this.escape(`${responseBody}`);
+				console.log(`##teamcity[testFailed responseBody ='${responseBody}'`);
+			}
+			catch (e) {
+				console.log(`##teamcity[testFailed Exception : '${e}']`);
+			}
         }
         const duration = (this.currItem.response && this.currItem.response.responseTime) || 0;
         console.log(`##teamcity[testFinished name='${this.currItem.name}' duration='${duration}']`);


### PR DESCRIPTION
I had reported a bug for newman-reporter-teamcity recently. Error description:  https://github.com/leafle/newman-reporter-teamcity/issues/13 
After some investigation, I found a fix solution for index.js.  That is:
Change the code line from 
const responseCode = (this.currItem.response && this.currItem.response.responseTime) || "-";
to 
const responseCode = this.currItem.response.code;
By the way, I found some redundant log info could be removed (e.g. message='${msg}'). 
console.log(`##teamcity[testFailed name='${this.escape(args.item.name)}' message='${msg}' details='${msg} - ${details}']`);
In the meantime, as an improvement proposal, I suggest to add repsoneBody into the teamcity log when there is assertion failure, so that we can easily check the ResponseBody.