### PR TITLE
Add iterations to test names

### DIFF
--- a/lib/TeamcityReporter.js
+++ b/lib/TeamcityReporter.js
@@ -14,7 +14,7 @@ class TeamcityReporter {
     }
 
     beforeItem(err, args) {
-        this.currItem = {name: this.itemName(args.item), passed: true, failedAssertions: []};
+        this.currItem = {name: this.itemName(args.item, args.cursor), passed: true, failedAssertions: []};
         console.log(`##teamcity[testStarted name='${this.currItem.name}' captureStandardOutput='true' flowId='${this.flowId}']`);
     }
 
@@ -48,10 +48,11 @@ class TeamcityReporter {
     }
 
     /* HELPERS */
-    itemName(item) {
+    itemName(item, cursor) {
         const parentName = item.parent && item.parent() && item.parent().name ? item.parent().name : "";
         const folderOrEmpty = (!parentName || parentName === this.options.collection.name) ? "" : parentName + "/";
-        return this.escape(folderOrEmpty + item.name);
+        const iteration = cursor && cursor.cycles > 1 ? "/" + cursor.iteration : "";
+        return this.escape(folderOrEmpty + item.name + iteration);
     }
 
     /**

--- a/lib/TeamcityReporter.test.js
+++ b/lib/TeamcityReporter.test.js
@@ -29,6 +29,24 @@ test('#beforeItem correctly handles tests within a folder', () => {
   expect(outputData).toEqual(expect.stringMatching(/^##teamcity\[testStarted name='FolderName\/TestName' .*\]~~~$/));
 });
 
+test('#beforeItem correctly handles tests with iterations', () => {
+  const emitter = new EventEmitter();
+  const reporter = new TeamcityReporter(emitter, reporterOptions, options);
+
+  outputData = "";
+  console["log"] = jest.fn(storeLog);
+
+  let args2 = args;
+  args2 = {
+    ...args,
+    cursor: { iteration: 2, cycles: 4 },
+  };
+
+  emitter.emit('beforeItem', err, args2);
+  expect(outputData).toEqual(expect.stringMatching(/^##teamcity\[testStarted name='FolderName\/TestName\/2' .*\]~~~$/));
+});
+
+
 test('#item reports response code of failed requests correctly', () => {
   const emitter = new EventEmitter();
   const reporter = new TeamcityReporter(emitter, reporterOptions, options);


### PR DESCRIPTION
At the moment names of tests with iterations (When using data file) are the same between iterations.
This results in TeamCity reporting them as the same test.
This means if one iteration fails but the following one succeeds TeamCity will not report the test as a failure.

This PR adds iteration index to test names when running with iterations. This makes TeamCity treat each iteration as separate tests.